### PR TITLE
rm "include" in camera calibration cmakelists.txt

### DIFF
--- a/Perception/camera_calibration/CMakeLists.txt
+++ b/Perception/camera_calibration/CMakeLists.txt
@@ -108,7 +108,7 @@ find_package(Boost REQUIRED COMPONENTS system)
 ## CATKIN_DEPENDS: catkin_packages dependent projects also need
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
-  INCLUDE_DIRS include
+  INCLUDE_DIRS
   LIBRARIES camera_calibration
   CATKIN_DEPENDS cmake_modules eigen_stl_containers geometry_msgs pcl_conversions pcl_ros roscpp sensor_msgs shape_msgs std_msgs tf visualization_msgs
   DEPENDS system_lib


### PR DESCRIPTION
removed "include" from INCLUDE_DIRS in pick-and-place/Perception/camera_calibration/CMakeLists.txt